### PR TITLE
Adds useful functions for working with models.

### DIFF
--- a/src/v7400/document.rs
+++ b/src/v7400/document.rs
@@ -5,7 +5,6 @@ use fbxcel::tree::v7400::Tree;
 use crate::v7400::{
     connection::ConnectionsCache,
     definition::DefinitionsCache,
-    object::property::{PropertiesHandle, PropertiesNodeId},
     object::{scene::SceneHandle, ObjectHandle, ObjectsCache},
 };
 
@@ -60,20 +59,6 @@ impl Document {
             SceneHandle::new(obj_id.to_object_handle(self))
                 .expect("Should never fail: Actually using `Document` objects")
         })
-    }
-
-    /// Returns the "GlobalSettings" root level property block, if one exists.
-    pub fn global_settings(&self) -> Option<PropertiesHandle> {
-        let property_node = self
-            .tree()
-            .root()
-            .children_by_name("GlobalSettings")
-            .next()?
-            .children_by_name("Properties70")
-            .next()?;
-
-        let handle = PropertiesHandle::new(PropertiesNodeId::new(property_node.node_id()), self);
-        Some(handle)
     }
 }
 

--- a/src/v7400/document.rs
+++ b/src/v7400/document.rs
@@ -73,7 +73,7 @@ impl Document {
             .next()?;
 
         let handle = PropertiesHandle::new(PropertiesNodeId::new(property_node.node_id()), self);
-        return Some(handle);
+        Some(handle)
     }
 }
 

--- a/src/v7400/document.rs
+++ b/src/v7400/document.rs
@@ -5,8 +5,8 @@ use fbxcel::tree::v7400::Tree;
 use crate::v7400::{
     connection::ConnectionsCache,
     definition::DefinitionsCache,
-    object::{scene::SceneHandle, ObjectHandle, ObjectsCache},
     object::property::{PropertiesHandle, PropertiesNodeId},
+    object::{scene::SceneHandle, ObjectHandle, ObjectsCache},
 };
 
 pub use self::loader::Loader;
@@ -64,7 +64,9 @@ impl Document {
 
     /// Returns the "GlobalSettings" root level property block, if one exists.
     pub fn global_settings(&self) -> Option<PropertiesHandle> {
-        let property_node = self.tree().root()
+        let property_node = self
+            .tree()
+            .root()
             .children_by_name("GlobalSettings")
             .next()?
             .children_by_name("Properties70")

--- a/src/v7400/document.rs
+++ b/src/v7400/document.rs
@@ -6,6 +6,7 @@ use crate::v7400::{
     connection::ConnectionsCache,
     definition::DefinitionsCache,
     object::{scene::SceneHandle, ObjectHandle, ObjectsCache},
+    object::property::{PropertiesHandle, PropertiesNodeId},
 };
 
 pub use self::loader::Loader;
@@ -59,6 +60,18 @@ impl Document {
             SceneHandle::new(obj_id.to_object_handle(self))
                 .expect("Should never fail: Actually using `Document` objects")
         })
+    }
+
+    /// Returns the "GlobalSettings" root level property block, if one exists.
+    pub fn global_settings(&self) -> Option<PropertiesHandle> {
+        let property_node = self.tree().root()
+            .children_by_name("GlobalSettings")
+            .next()?
+            .children_by_name("Properties70")
+            .next()?;
+
+        let handle = PropertiesHandle::new(PropertiesNodeId::new(property_node.node_id()), self);
+        return Some(handle);
     }
 }
 

--- a/src/v7400/object/model.rs
+++ b/src/v7400/object/model.rs
@@ -6,6 +6,8 @@ pub use self::{
     camera::CameraHandle, light::LightHandle, limbnode::LimbNodeHandle, mesh::MeshHandle,
     null::NullHandle,
 };
+use mint::Vector3;
+use fbxcel::low::v7400::AttributeValue;
 
 mod camera;
 mod light;
@@ -56,5 +58,57 @@ impl<'a> ModelHandle<'a> {
                 TypedObjectHandle::Model(o) => Some(o),
                 _ => None,
             })
+    }
+
+    /// Gets the root-most model parent of this object in the scene hierarchy.
+    ///
+    /// If this object has no parents, returns this object.
+    ///
+    /// There may be multiple root models in a single scene.
+    pub fn root_model<'b>(&'b self) -> TypedModelHandle<'a> {
+        let mut parent : TypedModelHandle = match self.get_typed() {
+            TypedObjectHandle::Model(o) => o,
+            _ => panic!("ModelHandle should always have TypedObjectHandle::Model type.")
+        };
+
+        while let Some(m) = parent.parent_model() {
+            parent = m;
+        }
+        return parent;
+    }
+
+    /// Returns the local rotation (Lcl Rotation) of this model object, if one is present.
+    pub fn local_rotation(&self) -> Option<Vector3<f64>> {
+        let rotation = self.direct_properties()?.get_property("Lcl Rotation")?;
+
+        // Pull out the first three float attributes.
+        let components: Vec<f64> = rotation.node().attributes().iter().filter_map(|attr| {
+            return match attr {
+                AttributeValue::F64(value) => Some(value.clone()),
+                _ => None
+            }
+        }).collect();
+
+        // todo: Is it ever possible for a rotation to return a quaternion (ie. 4 values)?
+        assert_eq!(components.len(), 3);
+
+        return Some(Vector3::from_slice(components.as_slice()));
+    }
+
+    /// Returns the local scale (Lcl Scale) of this model object, if one is present.
+    pub fn local_scale(&self) -> Option<Vector3<f64>> {
+        let rotation = self.direct_properties()?.get_property("Lcl Scaling")?;
+
+        // Pull out the first three float attributes.
+        let components: Vec<f64> = rotation.node().attributes().iter().filter_map(|attr| {
+            return match attr {
+                AttributeValue::F64(value) => Some(value.clone()),
+                _ => None
+            }
+        }).collect();
+
+        assert_eq!(components.len(), 3);
+
+        return Some(Vector3::from_slice(components.as_slice()));
     }
 }

--- a/src/v7400/object/model.rs
+++ b/src/v7400/object/model.rs
@@ -78,21 +78,12 @@ impl<'a> ModelHandle<'a> {
     }
 
     /// Returns the local rotation (Lcl Rotation) of this model object, if one is present.
-    pub fn local_rotation(&self) -> Option<Vector3<f64>> {
-        let rotation = self.direct_properties()?.get_property("Lcl Rotation")?;
-
-        // Pull out the first three float attributes.
-        let components: Vec<f64> = rotation.node().attributes().iter().filter_map(|attr| {
-            return match attr {
-                AttributeValue::F64(value) => Some(value.clone()),
-                _ => None
-            }
-        }).collect();
-
-        // todo: Is it ever possible for a rotation to return a quaternion (ie. 4 values)?
-        assert_eq!(components.len(), 3);
-
-        return Some(Vector3::from_slice(components.as_slice()));
+    pub fn local_rotation(&self) -> anyhow::Result<Option<Vector3<f64>>> {
+        // `Model` objects have native typename `FbxNode`.
+        self.properties_by_native_typename("FbxNode")
+            .get_property("Lcl Rotation")
+            .map(|prop| prop.load_value(MintLoader::<Vector3<f64>>::new()))
+            .transpose()
     }
 
     /// Returns the local scale (Lcl Scale) of this model object, if one is present.

--- a/src/v7400/object/model.rs
+++ b/src/v7400/object/model.rs
@@ -77,6 +77,15 @@ impl<'a> ModelHandle<'a> {
         parent
     }
 
+    /// Returns the local translation (Lcl Translation) of this model object, if one is present.
+    pub fn local_translation(&self) -> anyhow::Result<Option<Vector3<f64>>> {
+        // `Model` objects have native typename `FbxNode`.
+        self.properties_by_native_typename("FbxNode")
+            .get_property("Lcl Translation")
+            .map(|prop| prop.load_value(MintLoader::<Vector3<f64>>::new()))
+            .transpose()
+    }
+
     /// Returns the local rotation (Lcl Rotation) of this model object, if one is present.
     pub fn local_rotation(&self) -> anyhow::Result<Option<Vector3<f64>>> {
         // `Model` objects have native typename `FbxNode`.

--- a/src/v7400/object/model.rs
+++ b/src/v7400/object/model.rs
@@ -6,9 +6,9 @@ pub use self::{
     camera::CameraHandle, light::LightHandle, limbnode::LimbNodeHandle, mesh::MeshHandle,
     null::NullHandle,
 };
-use mint::Vector3;
-use fbxcel::low::v7400::AttributeValue;
 use crate::v7400::object::property::loaders::MintLoader;
+use fbxcel::low::v7400::AttributeValue;
+use mint::Vector3;
 
 mod camera;
 mod light;
@@ -67,9 +67,9 @@ impl<'a> ModelHandle<'a> {
     ///
     /// There may be multiple root models in a single scene.
     pub fn root_model<'b>(&'b self) -> TypedModelHandle<'a> {
-        let mut parent : TypedModelHandle = match self.get_typed() {
+        let mut parent: TypedModelHandle = match self.get_typed() {
             TypedObjectHandle::Model(o) => o,
-            _ => panic!("ModelHandle should always have TypedObjectHandle::Model type.")
+            _ => panic!("ModelHandle should always have TypedObjectHandle::Model type."),
         };
 
         while let Some(m) = parent.parent_model() {

--- a/src/v7400/object/model.rs
+++ b/src/v7400/object/model.rs
@@ -7,7 +7,6 @@ pub use self::{
     null::NullHandle,
 };
 use crate::v7400::object::property::loaders::MintLoader;
-use fbxcel::low::v7400::AttributeValue;
 use mint::Vector3;
 
 mod camera;

--- a/src/v7400/object/model.rs
+++ b/src/v7400/object/model.rs
@@ -87,7 +87,7 @@ impl<'a> ModelHandle<'a> {
     }
 
     /// Returns the local scale (Lcl Scale) of this model object, if one is present.
-    pub fn local_scale(&self) -> anyhow::Result<Option<Vector3<f64>>> {
+    pub fn local_scaling(&self) -> anyhow::Result<Option<Vector3<f64>>> {
         // `Model` objects have native typename `FbxNode`.
         self.properties_by_native_typename("FbxNode")
             .get_property("Lcl Scaling")

--- a/src/v7400/object/model.rs
+++ b/src/v7400/object/model.rs
@@ -60,9 +60,9 @@ impl<'a> ModelHandle<'a> {
             })
     }
 
-    /// Gets the root-most model parent of this object in the scene hierarchy.
+    /// Returns the root-most model ancestor of this object in the scene hierarchy.
     ///
-    /// If this object has no parents, returns this object.
+    /// If this object has no parent models, returns this object.
     ///
     /// There may be multiple root models in a single scene.
     pub fn root_model<'b>(&'b self) -> TypedModelHandle<'a> {

--- a/src/v7400/object/model.rs
+++ b/src/v7400/object/model.rs
@@ -74,7 +74,7 @@ impl<'a> ModelHandle<'a> {
         while let Some(m) = parent.parent_model() {
             parent = m;
         }
-        return parent;
+        parent
     }
 
     /// Returns the local rotation (Lcl Rotation) of this model object, if one is present.


### PR DESCRIPTION
Still wrapping my head around Rust, so definitely let me know if my code is odd.

Additionally, I wrote a number of functions for my own usage, which I've copied below. I wasn't sure they were worth submitting, but let me know if you would prefer me to add them to fbxcel-dom as well.

```
// could be worth contributing, not sure

#[derive(Debug, PartialEq)]
struct CoordinateAxis {
    up: Vector3<f64>,
    front: Vector3<f64>,
    coord: Vector3<f64>,
}

fn get_coordinate_axis(doc: &Document) -> Option<CoordinateAxis> {
    let global_settings = doc
        .global_settings()
        .ok_or("Count not find global settings in file.")
        .ok()?;

    let upAxis = get_axis(&global_settings, "UpAxis")?;
    let frontAxis = get_axis(&global_settings, "FrontAxis")?;
    let coordAxis = get_axis(&global_settings, "CoordAxis")?;

    Some(CoordinateAxis {
        up: upAxis,
        front: frontAxis,
        coord: coordAxis,
    })
}

fn get_axis(global_settings: &PropertiesHandle, name: &str) -> Option<Vector3<f64>> {
    let axis = if let AttributeValue::I32(v) = global_settings
        .get_property(name)?
        .value_part()
        .get(0)? {
        v
    } else {
        return None;
    };

    let sign = if let AttributeValue::I32(v) = global_settings
        .get_property(&(name.to_owned() + "Sign"))?
        .value_part()
        .get(0)?
    {
        v
    } else {
        return None;
    };

    Some(match axis {
        0 => [*sign as f64, 0f64, 0f64].into(),
        1 => [0f64, *sign as f64, 0f64].into(),
        2 => [0f64, 0f64, *sign as f64].into(),
        _ => return None
    })
}

fn get_models<'a>(doc: &'a Document) -> impl Iterator<Item=TypedModelHandle<'a>> {
    return doc.objects().filter_map(|o| {
        if let TypedObjectHandle::Model(model) = o.get_typed() {
            return Some(model);
        }
        return None;
    });
}

fn get_model_roots<'a>(doc: &'a Document) -> Vec<TypedModelHandle<'a>> {
    let mut results: HashMap<ObjectId, TypedModelHandle> = HashMap::new();
    for model in get_models(doc) {
        let root = model.root_model();
        results.insert(root.object_id(), root);
    }
    let vec = results.values().cloned().collect();
    return vec;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lo48576/fbxcel-dom/3)
<!-- Reviewable:end -->
