### PR TITLE
Accessor for Mesh control points and indices.

### DIFF
--- a/src/v7400/data/mesh/control_point.rs
+++ b/src/v7400/data/mesh/control_point.rs
@@ -45,4 +45,15 @@ impl<'a> ControlPoints<'a> {
         }
         Some(Point3::from_slice(&self.data[i3..]))
     }
+
+    /// Returns an iterator through the control points
+    pub(crate) fn iter(&self) -> anyhow::Result<impl Iterator<Item = Point3<f64>> + 'a> {
+        if self.data.len() % 3 != 0 {
+            return Err(anyhow::format_err!(
+                "Mesh did not have valid vertex array size."
+            ));
+        }
+
+        Ok(self.data.chunks(3).map(|chunk| Point3::from_slice(chunk)))
+    }
 }

--- a/src/v7400/data/mesh/polygon_vertex_index.rs
+++ b/src/v7400/data/mesh/polygon_vertex_index.rs
@@ -66,6 +66,16 @@ impl<'a> PolygonVertices<'a> {
         }
     }
 
+    /// Returns the raw control points
+    pub fn raw_control_points(&self) -> anyhow::Result<impl Iterator<Item = Point3<f64>> + 'a> {
+        self.control_points.iter()
+    }
+
+    /// Returns a slice of the raw polygon vertices (indices).
+    pub fn raw_polygon_vertices(&self) -> &[i32] {
+        self.polygon_vertices.data
+    }
+
     /// Returns a polygon vertex at the given index.
     pub fn polygon_vertex(&self, pvi: PolygonVertexIndex) -> Option<PolygonVertex> {
         self.polygon_vertices.get(pvi)
@@ -140,7 +150,7 @@ pub struct PolygonVertex(i32);
 
 impl PolygonVertex {
     /// Creates a new `PolygonVertex`.
-    pub(crate) fn new(i: i32) -> Self {
+    pub fn new(i: i32) -> Self {
         Self(i)
     }
 


### PR DESCRIPTION
I needed these changes to implement the downstream application. There may be another way to access this data, but I wasn't able to find it.

- I needed a way to iterate through the vertex positions to calculate a mesh's bounding box.
- I needed access to the polygon indices in order write a routine that detects quads/pentagons, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lo48576/fbxcel-dom/5)
<!-- Reviewable:end -->
