### PR TITLE
Adds a GlobalSettings struct.

### DIFF
--- a/src/v7400.rs
+++ b/src/v7400.rs
@@ -64,6 +64,6 @@ pub use self::{
 pub(crate) mod connection;
 pub mod data;
 mod definition;
-mod document;
+pub mod document;
 pub(crate) mod error;
 pub mod object;

--- a/src/v7400/document.rs
+++ b/src/v7400/document.rs
@@ -8,8 +8,11 @@ use crate::v7400::{
     object::{scene::SceneHandle, ObjectHandle, ObjectsCache},
 };
 
+pub use self::global_settings::GlobalSettings;
 pub use self::loader::Loader;
+use crate::v7400::object::property::{PropertiesHandle, PropertiesNodeId};
 
+mod global_settings;
 mod loader;
 
 /// FBX DOM.
@@ -59,6 +62,21 @@ impl Document {
             SceneHandle::new(obj_id.to_object_handle(self))
                 .expect("Should never fail: Actually using `Document` objects")
         })
+    }
+
+    /// Returns the "GlobalSettings" root level property block, if one exists.
+    pub fn global_settings(&self) -> Option<GlobalSettings> {
+        let property_node = self
+            .tree()
+            .root()
+            .children_by_name("GlobalSettings")
+            .next()?
+            .children_by_name("Properties70")
+            .next()?;
+
+        let handle = PropertiesHandle::new(PropertiesNodeId::new(property_node.node_id()), self);
+
+        Some(GlobalSettings { properties: handle })
     }
 }
 

--- a/src/v7400/document/global_settings.rs
+++ b/src/v7400/document/global_settings.rs
@@ -1,0 +1,47 @@
+//! The Global Settings for the FBX file. See struct `GlobalSettings`.
+
+use crate::v7400::object::property::PropertiesHandle;
+use fbxcel::low::v7400::AttributeValue;
+
+/// The Global Settings for the FBX file.
+/// Similar to http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/class_fbx_global_settings.html,topicNumber=cpp_ref_class_fbx_global_settings_html121c7acd-33fd-4411-8710-deeff384f0f4
+pub struct GlobalSettings<'a> {
+    pub(crate) properties: PropertiesHandle<'a>,
+}
+
+impl<'a> GlobalSettings<'a> {
+    /// Returns the unit scale of the file. This is relative to 1 centimeter: A file
+    /// with scale in meters will have a UnitScaleFactor of "100.0".
+    pub fn unit_scale_factor(&self) -> f64 {
+        match self.unit_scale_factor_raw() {
+            Some(unit) => unit,
+            None => 1.0, // The default unit is assumed to be centimeters.
+        }
+    }
+
+    /// Returns the raw UnitScaleFactor of the file. This is relative to 1 centimeter. ie. A file
+    /// with scale in meters will have a UnitScaleFactor of "100.0"
+    ///
+    /// This function will return None if no unit is specified, however an FBX with no units
+    /// is assumed to be in centimeters by default.
+    ///
+    /// In most cases, you should use `unit_scale_factor` instead.
+    pub fn unit_scale_factor_raw(&self) -> Option<f64> {
+        match self
+            .properties
+            .get_property("UnitScaleFactor")?
+            .value_part()
+            .get(0)?
+        {
+            AttributeValue::F64(unit) => Some(*unit),
+            _ => None,
+        }
+    }
+
+    /// Returns a property accessor handle that can be used to query properties using the string name.
+    ///
+    /// This is an escape hatch for properties that are not yet exposed as functions on this object.
+    pub fn raw_properties(&self) -> &PropertiesHandle<'a> {
+        &self.properties
+    }
+}


### PR DESCRIPTION
Exposes a struct-based API for accessing GlobalSettings properties. Currently only supports unit_scale_factor and the mentioned escape hatch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lo48576/fbxcel-dom/7)
<!-- Reviewable:end -->
