### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/v7400/data/mesh/layer/common.rs
+++ b/src/v7400/data/mesh/layer/common.rs
@@ -245,7 +245,9 @@ impl LayerContentIndex {
         tri_vi: TriangleVertexIndex,
     ) -> Result<LayerContentIndex, Error> {
         let index = match mapping_mode {
-            MappingMode::None | MappingMode::ByEdge => bail!("Unsupported mapping mode: {:?}"),
+            MappingMode::None | MappingMode::ByEdge => {
+                bail!("Unsupported mapping mode: {:?}", mapping_mode);
+            }
             MappingMode::ByControlPoint => {
                 let cpi = triangle_vertices
                     .control_point_index(tri_vi)


### PR DESCRIPTION
Without this, the error message would literally be "Unsupported mapping mode: {:?}" with curly braces in it instead of the mapping mode.