### PR TITLE
Add some more texture accessors

### DIFF
--- a/src/v7400/object/material.rs
+++ b/src/v7400/object/material.rs
@@ -47,12 +47,12 @@ impl<'a> MaterialHandle<'a> {
     }
 
     /// Returns the specular color texture of this material if available.
-    pub fn specular_color_texture(&self) -> Option<texture::TextureHandle<'a>> {
+    pub fn specular_texture(&self) -> Option<texture::TextureHandle<'a>> {
         get_texture_node(self, "SpecularColor")
     }
 
     /// Returns the emissive color texture of this material if available.
-    pub fn emissive_color_texture(&self) -> Option<texture::TextureHandle<'a>> {
+    pub fn emissive_texture(&self) -> Option<texture::TextureHandle<'a>> {
         get_texture_node(self, "EmissiveColor")
     }
 

--- a/src/v7400/object/material.rs
+++ b/src/v7400/object/material.rs
@@ -41,6 +41,21 @@ impl<'a> MaterialHandle<'a> {
         get_texture_node(self, "TransparentColor")
     }
 
+    /// Returns the normal map of this material if available.
+    pub fn normal_map_texture(&self) -> Option<texture::TextureHandle<'a>> {
+        get_texture_node(self, "NormalMap")
+    }
+
+    /// Returns the specular color texture of this material if available.
+    pub fn specular_color_texture(&self) -> Option<texture::TextureHandle<'a>> {
+        get_texture_node(self, "SpecularColor")
+    }
+
+    /// Returns the emissive color texture of this material if available.
+    pub fn emissive_color_texture(&self) -> Option<texture::TextureHandle<'a>> {
+        get_texture_node(self, "EmissiveColor")
+    }
+
     /// Returns properties.
     pub fn properties(&self) -> MaterialProperties<'a> {
         // Find phong properties, then lambert.


### PR DESCRIPTION
It's possible to do it manually by accessing the raw fbx tree through `fbxcel`, but might as well provide better methods.