### PR TITLE
Add a minimal GlobalSettings accessor

### DIFF
--- a/src/v7400/document.rs
+++ b/src/v7400/document.rs
@@ -8,8 +8,11 @@ use crate::v7400::{
     object::{scene::SceneHandle, ObjectHandle, ObjectsCache},
 };
 
+pub use self::global_settings::GlobalSettings;
 pub use self::loader::Loader;
+use crate::v7400::object::property::PropertiesHandle;
 
+mod global_settings;
 mod loader;
 
 /// FBX DOM.
@@ -59,6 +62,13 @@ impl Document {
             SceneHandle::new(obj_id.to_object_handle(self))
                 .expect("Should never fail: Actually using `Document` objects")
         })
+    }
+
+    /// Returns the "GlobalSettings" root level property block, if one exists.
+    pub fn global_settings(&self) -> Option<GlobalSettings> {
+        let settings_node = self.tree().root().first_child_by_name("GlobalSettings")?;
+        let properties = PropertiesHandle::from_node(settings_node, self)?;
+        Some(GlobalSettings { properties })
     }
 }
 

--- a/src/v7400/document/global_settings.rs
+++ b/src/v7400/document/global_settings.rs
@@ -1,0 +1,16 @@
+//! The Global Settings for the FBX file. See struct `GlobalSettings`.
+
+use crate::v7400::object::property::PropertiesHandle;
+
+/// The Global Settings for the FBX file.
+/// Similar to http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/class_fbx_global_settings.html,topicNumber=cpp_ref_class_fbx_global_settings_html121c7acd-33fd-4411-8710-deeff384f0f4
+pub struct GlobalSettings<'a> {
+    pub(crate) properties: PropertiesHandle<'a>,
+}
+
+impl<'a> GlobalSettings<'a> {
+    /// Returns a property accessor handle that can be used to query properties using the string name.
+    pub fn raw_properties(&self) -> &PropertiesHandle<'a> {
+        &self.properties
+    }
+}

--- a/src/v7400/object/property/properties.rs
+++ b/src/v7400/object/property/properties.rs
@@ -52,19 +52,16 @@ impl<'a> PropertiesHandle<'a> {
         Self { node_id, doc }
     }
 
+    pub(crate) fn from_node(node: NodeHandle<'a>, doc: &'a Document) -> Option<Self> {
+        let properties_node = node.first_child_by_name("Properties70")?;
+        let node_id = PropertiesNodeId::new(properties_node.node_id());
+        Some(Self { node_id, doc })
+    }
+
     /// Creates a new `ObjectProperties` for the given object node and native
     /// type name.
     pub(crate) fn from_object(object: &ObjectHandle<'a>) -> Option<Self> {
-        let node_id = object
-            .node()
-            .children_by_name("Properties70")
-            .map(|node| PropertiesNodeId::new(node.node_id()))
-            .next()?
-            .into();
-        Some(Self {
-            node_id: PropertiesNodeId::new(node_id),
-            doc: object.document(),
-        })
+        Self::from_node(object.node(), object.document())
     }
 
     /// Returns a node handle for the properties node.


### PR DESCRIPTION
Expose a `GlobalSettings` struct to access document-wide settings
information, such as scale factor or axis direction.

The API as defined in this PR is EXTREMELY BAREBONE, requiring
the user to manually specify the name of the properties they want to
access.

This is in order to avoid blocking on any particular details. Favoring
further discussions about unit precision or how to expose a proper
axis direction API for later.

I'd really like to see this go through, it's a blocker for some features on https://github.com/HeavyRain266/bevy_fbx/

See also:
- https://github.com/lo48576/fbxcel-dom/pull/7