### PR TITLE
Make DuplicatiteConnection a warning instead of error

### DIFF
--- a/src/v7400/connection/cache.rs
+++ b/src/v7400/connection/cache.rs
@@ -6,8 +6,8 @@ use fbxcel::{
     low::v7400::AttributeValue,
     tree::v7400::{NodeHandle, NodeId, Tree},
 };
-use log::trace;
-use log::warn;
+
+use log::{trace, warn};
 use string_interner::{DefaultBackend, StringInterner};
 
 use crate::v7400::{
@@ -131,18 +131,22 @@ impl ConnectionsCacheBuilder {
                 .expect("Should never fail: entry should exist");
 
             warn!(
-                    "Found duplicated connection node (node_id={:?}): \
-                    source_id={:?}, destination_id={:?}, label={:?}, first_conn={:?}",
-                    node.node_id(),
-                    conn.source_id(), conn.destination_id(), conn.label_sym()
-                        .map(|sym| {
-                             self.labels.resolve(sym).expect(
-                                 "Should never fail: connection label symbol should be registered",
-                             )
-                        })
-                        .map(ToOwned::to_owned),
-                    old_conn.0
-                );
+                "Found duplicated connection node, skipping (node_id={:?}): \
+                 source_id={:?}, destination_id={:?}, label={:?}, first_conn={:?}",
+                node.node_id(),
+                conn.source_id(),
+                conn.destination_id(),
+                conn.label_sym()
+                    .map(|sym| {
+                        self.labels.resolve(sym).expect(
+                            "Should never fail: connection label symbol should be registered",
+                        )
+                    })
+                    .map(ToOwned::to_owned),
+                old_conn.0
+            );
+
+            return Ok(());
         }
         self.connections.push((node.node_id(), conn));
         self.conn_indices_by_src

--- a/src/v7400/error/connection.rs
+++ b/src/v7400/error/connection.rs
@@ -4,21 +4,11 @@ use std::{error, fmt};
 
 use fbxcel::{low::v7400::AttributeType, tree::v7400::NodeId};
 
-use crate::v7400::{connection::ConnectionIndex, object::ObjectId, LoadError};
+use crate::v7400::{connection::ConnectionIndex, LoadError};
 
 /// Object metadata load error.
 #[derive(Debug, Clone)]
 pub(crate) enum ConnectionError {
-    /// Duplicate object ID.
-    DuplicateConnection(
-        ObjectId,
-        ObjectId,
-        Option<String>,
-        NodeId,
-        ConnectionIndex,
-        NodeId,
-        ConnectionIndex,
-    ),
     /// Node types not found.
     MissingNodeTypes(NodeId, ConnectionIndex),
     /// Invalid type value of node types.
@@ -40,20 +30,6 @@ pub(crate) enum ConnectionError {
 impl fmt::Display for ConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ConnectionError::DuplicateConnection(
-                source,
-                dest,
-                label,
-                conn_node1,
-                conn_index1,
-                conn_node2,
-                conn_index2,
-            ) => write!(
-                f,
-                "Duplicate connections: source={:?}, dest={:?}, label={:?} \
-                 node1={:?}, index1={:?}, node2={:?}, index2={:?}",
-                source, dest, label, conn_node1, conn_index1, conn_node2, conn_index2
-            ),
             ConnectionError::MissingNodeTypes(node, conn_index) => write!(
                 f,
                 "Connection node types not found: node={:?}, conn_index={:?}",


### PR DESCRIPTION
It's probably better to warn the user when the duplicate is found instead of throwing an error

While loading [this model](https://github.com/zeroruka/GI-Assets/blob/main/Models/Characters/Fischl/Highness/Avatar_Girl_Bow_FischlCostumeHighness.fbx) I encounter the `DuplicateConnection` error. I tested importing this model in Blender and Unity and it worked just fine so I think it probably will be better to allow loading models with duplicated connections while warning the user that such a connection is found
I also checked [blenders docs](https://archive.blender.org/wiki/index.php/User:Mont29/Foundation/FBX_File_Structure/#Connections) and [their loader](https://github.com/blender/blender-addons/blob/7d80f2f97161fc8e353a657b179b9aa1f8e5280b/io_scene_fbx/import_fbx.py#L2719) and didn't find any constraints on duplicated connection nodes