### PR TITLE
Add tangents and normal map UV

### DIFF
--- a/src/v7400/data/mesh/layer.rs
+++ b/src/v7400/data/mesh/layer.rs
@@ -12,6 +12,7 @@ pub use self::{
     common::{LayerElementHandle, MappingMode, ReferenceInformation, ReferenceMode},
     material::LayerElementMaterialHandle,
     normal::LayerElementNormalHandle,
+    tangent::LayerElementTangentHandle,
     uv::LayerElementUvHandle,
 };
 
@@ -19,6 +20,7 @@ pub mod color;
 mod common;
 pub mod material;
 pub mod normal;
+pub mod tangent;
 pub mod uv;
 
 /// Layer node.
@@ -190,8 +192,12 @@ pub enum LayerElementType {
     Material,
     /// Normal.
     Normal,
+    /// Tangent.
+    Tangent,
     /// UV.
     Uv,
+    /// Normal map UV.
+    NormalMapUv
 }
 
 impl LayerElementType {
@@ -202,6 +208,8 @@ impl LayerElementType {
             LayerElementType::Material => "LayerElementMaterial",
             LayerElementType::Normal => "LayerElementNormal",
             LayerElementType::Uv => "LayerElementUV",
+            LayerElementType::NormalMapUv => "LayerElementNormalMapUV",
+            LayerElementType::Tangent => "LayerElementTangent",
         }
     }
 }
@@ -215,6 +223,8 @@ impl TryFrom<&str> for LayerElementType {
             "LayerElementMaterial" => Ok(LayerElementType::Material),
             "LayerElementNormal" => Ok(LayerElementType::Normal),
             "LayerElementUV" => Ok(LayerElementType::Uv),
+            "LayerElementNormalMapUV" => Ok(LayerElementType::NormalMapUv),
+            "LayerElementTangent" => Ok(LayerElementType::Tangent),
             _ => Err(format_err!("Unknown layer element type: {:?}", s)),
         }
     }
@@ -259,8 +269,12 @@ pub enum TypedLayerElementHandle<'a> {
     Material(LayerElementMaterialHandle<'a>),
     /// Normal.
     Normal(LayerElementNormalHandle<'a>),
+    /// Tangent.
+    Tangent(LayerElementTangentHandle<'a>),
     /// UV.
     Uv(LayerElementUvHandle<'a>),
+    /// Normal Map UV.
+    NormalMapUv(LayerElementUvHandle<'a>),
 }
 
 impl<'a> TypedLayerElementHandle<'a> {
@@ -277,7 +291,11 @@ impl<'a> TypedLayerElementHandle<'a> {
             LayerElementType::Normal => {
                 TypedLayerElementHandle::Normal(LayerElementNormalHandle::new(base))
             }
+            LayerElementType::Tangent => {
+                TypedLayerElementHandle::Tangent(LayerElementTangentHandle::new(base))
+            }
             LayerElementType::Uv => TypedLayerElementHandle::Uv(LayerElementUvHandle::new(base)),
+            LayerElementType::NormalMapUv => TypedLayerElementHandle::NormalMapUv(LayerElementUvHandle::new(base)),
         }
     }
 }
@@ -291,6 +309,8 @@ impl<'a> std::ops::Deref for TypedLayerElementHandle<'a> {
             TypedLayerElementHandle::Normal(v) => &**v,
             TypedLayerElementHandle::Material(v) => &**v,
             TypedLayerElementHandle::Uv(v) => &**v,
+            TypedLayerElementHandle::NormalMapUv(v) => &**v,
+            TypedLayerElementHandle::Tangent(v) => &**v,
         }
     }
 }

--- a/src/v7400/data/mesh/layer/common.rs
+++ b/src/v7400/data/mesh/layer/common.rs
@@ -139,6 +139,7 @@ impl TryFrom<&str> for MappingMode {
             "ByPolygon" => Ok(MappingMode::ByPolygon),
             "ByEdge" => Ok(MappingMode::ByEdge),
             "AllSame" => Ok(MappingMode::AllSame),
+            "NoMappingInformation" => Ok(MappingMode::None),
             s => Err(format_err!("Failed to parse mapping mode: got {:?}", s)),
         }
     }

--- a/src/v7400/data/mesh/layer/tangent.rs
+++ b/src/v7400/data/mesh/layer/tangent.rs
@@ -1,0 +1,95 @@
+//! Tangent.
+
+use anyhow::{bail, format_err, Error};
+use mint::Vector3;
+
+use crate::v7400::data::mesh::{
+    layer::{
+        LayerContentIndex, LayerElementHandle, MappingMode, ReferenceInformation, ReferenceMode,
+    },
+    TriangleVertexIndex, TriangleVertices,
+};
+
+/// Layer element node handle.
+#[derive(Debug, Clone, Copy)]
+pub struct LayerElementTangentHandle<'a> {
+    /// `LayerElementTangent` node.
+    node: LayerElementHandle<'a>,
+}
+
+impl<'a> LayerElementTangentHandle<'a> {
+    /// Creates a new `LayerElementTangentHandle`.
+    pub fn new(node: LayerElementHandle<'a>) -> Self {
+        Self { node }
+    }
+
+    /// Returns `Tangents` data.
+    pub fn tangents(&self) -> Result<Tangents<'a>, Error> {
+        Tangents::new(self)
+    }
+
+    /// Returns reference to the tangents (xyz) slice.
+    fn tangents_vec3_slice(&self) -> Result<&'a [f64], Error> {
+        self.children_by_name("Tangents")
+            .next()
+            .ok_or_else(|| format_err!("No `Tangents` found for `LayerElementTangent` node"))?
+            .attributes()
+            .get(0)
+            .ok_or_else(|| format_err!("No attributes found for `Tangents` node"))?
+            .get_arr_f64_or_type()
+            .map_err(|ty| format_err!("Expected `[f64]` as tangents, but got {:?}", ty))
+    }
+}
+
+impl<'a> std::ops::Deref for LayerElementTangentHandle<'a> {
+    type Target = LayerElementHandle<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.node
+    }
+}
+
+/// Tangents.
+#[derive(Debug, Clone, Copy)]
+pub struct Tangents<'a> {
+    /// Tangents.
+    tangents: &'a [f64],
+    /// Mapping mode.
+    mapping_mode: MappingMode,
+}
+
+impl<'a> Tangents<'a> {
+    /// Creates a new `Tangents`.
+    fn new(handle: &LayerElementTangentHandle<'a>) -> Result<Self, Error> {
+        let tangents = handle.tangents_vec3_slice()?;
+        let mapping_mode = handle.mapping_mode()?;
+        let reference_mode = handle.reference_mode()?;
+        if reference_mode != ReferenceMode::Direct {
+            bail!(
+                "Unsupported reference mode for tangents: {:?}",
+                reference_mode
+            );
+        }
+        Ok(Self {
+            tangents,
+            mapping_mode,
+        })
+    }
+
+    /// Returns `[f64; 3]` tangent corresponding to the given triangle vertex
+    /// index.
+    pub fn tangent(
+        &self,
+        tris: &TriangleVertices<'a>,
+        tri_vi: TriangleVertexIndex,
+    ) -> Result<Vector3<f64>, Error> {
+        let i = LayerContentIndex::control_point_data_from_triangle_vertices(
+            ReferenceInformation::Direct,
+            self.mapping_mode,
+            tris,
+            self.tangents.len() / 3,
+            tri_vi,
+        )?;
+        Ok(Vector3::from_slice(&self.tangents[(i.get() * 3)..]))
+    }
+}


### PR DESCRIPTION
Still trying to load [this model](https://github.com/zeroruka/GI-Assets/blob/main/Models/Characters/Fischl/Highness/Avatar_Girl_Bow_FischlCostumeHighness.fbx) which contains a few `LayerElements` that are currently missing from this implementation. It is possible to use raw fbx layout to get them but I think having build-in types is better and more convenient. 

Add missing `TypedLayerElements` `Tangent` and `NormalMapUV` ([FBX SDK Tangent](https://docs.unity3d.com/Packages/com.autodesk.fbx@3.0/api/Autodesk.Fbx.FbxLayerElementTangent.html),  [FBX SDK NormalMapUV](https://download.autodesk.com/us/fbx/sdkdocs/fbx_sdk_help/files/fbxsdkref/class_k_fbx_layer.html#28559696882666e74a97c0915d6686e6) )
Add 'NoMappingInformation' case handle for mapping mode ([FBX SDK define](https://github.com/metarutaiga/FBXSDK/blob/350d9856c9f560a3817df915bf99fd937c011174/include/fbxsdk/fileio/fbxfiletokens.h#L455))